### PR TITLE
Add xhr error catching

### DIFF
--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -46,7 +46,7 @@ else {
         if (xhr.readyState !== 4) return;
         // Give onTimeout a chance to run first if that's the reason status is 0.
         if (!xhr.status) return setTimeout(onReadyStateChange, 0);
-        if (!(xhr.status >= 200 && xhr.status < 300 || xhr.status === 304)) return callback(xhr.responseText);
+        if (!(xhr.status >= 200 && xhr.status < 300 || xhr.status === 304)) return callback(new Error("Connection error status " + xhr.status));
         done = true;
         var response = {message:xhr.responseText};
         if (xhr.responseText){


### PR DESCRIPTION
The xhr module currently does not catch connection errors from no network connection (caught by xhr.onerror) or from a non-valid status code in the response.
