### PR TITLE
added optional githubHostname parameter

### DIFF
--- a/lib/xhr-node.js
+++ b/lib/xhr-node.js
@@ -58,10 +58,10 @@ module.exports = function (root, accessToken, githubHostname) {
           };
         }
         else if (res.statusCode === 304) {
-            body = cache[url].body;
-            res.statusCode = 200;
+          body = cache[url].body;
+          res.statusCode = 200;
         }
-        //Fake parts of the xhr object using node APIs
+        // Fake parts of the xhr object using node APIs
         var xhr = {
           status: res.statusCode,
           statusText: res.statusCode + " " + statusCodes[res.statusCode]

--- a/lib/xhr-node.js
+++ b/lib/xhr-node.js
@@ -1,7 +1,7 @@
 var https = require('https');
 var statusCodes = require('http').STATUS_CODES;
 
-module.exports = function (root, accessToken) {
+module.exports = function (root, accessToken, githubHostname) {
   var cache = {};
   return function request(method, url, body, callback) {
     if (typeof body === "function" && callback === undefined) {
@@ -30,12 +30,14 @@ module.exports = function (root, accessToken) {
         headers["If-None-Match"] = cached.etag;
       }
     }
+    var urlparts = require('url').parse(githubHostname || "https://api.github.com/");
     var options = {
-      hostname: "api.github.com",
-      path: url,
+      hostname: urlparts.hostname,
+      path: urlparts.pathname + url,
       method: method,
       headers: headers
     };
+
     var req = https.request(options, function (res) {
       var body = [];
       res.on("data", function (chunk) {

--- a/lib/xhr-node.js
+++ b/lib/xhr-node.js
@@ -1,8 +1,10 @@
 var https = require('https');
 var statusCodes = require('http').STATUS_CODES;
+var urlParse = require('url').parse;
 
 module.exports = function (root, accessToken, githubHostname) {
   var cache = {};
+  githubHostname = (githubHostname || "https://api.github.com/");
   return function request(method, url, body, callback) {
     if (typeof body === "function" && callback === undefined) {
       callback = body;
@@ -30,7 +32,8 @@ module.exports = function (root, accessToken, githubHostname) {
         headers["If-None-Match"] = cached.etag;
       }
     }
-    var urlparts = require('url').parse(githubHostname || "https://api.github.com/");
+
+    var urlparts = urlParse(githubHostname);
     var options = {
       hostname: urlparts.hostname,
       path: urlparts.pathname + url,
@@ -47,6 +50,7 @@ module.exports = function (root, accessToken, githubHostname) {
         body = Buffer.concat(body).toString();
         console.log(method, url, res.statusCode);
         console.log("Rate limit %s/%s left", res.headers['x-ratelimit-remaining'], res.headers['x-ratelimit-limit']);
+        //console.log(body);
         if (res.statusCode === 200 && method === "GET" && /\/refs\//.test(url)) {
           cache[url] = {
             body: body,
@@ -54,10 +58,10 @@ module.exports = function (root, accessToken, githubHostname) {
           };
         }
         else if (res.statusCode === 304) {
-          body = cache[url].body;
-          res.statusCode = 200;
+            body = cache[url].body;
+            res.statusCode = 200;
         }
-        // Fake parts of the xhr object using node APIs
+        //Fake parts of the xhr object using node APIs
         var xhr = {
           status: res.statusCode,
           statusText: res.statusCode + " " + statusCodes[res.statusCode]

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -13,7 +13,7 @@ if (isNode) {
 
 // Browser XHR
 else {
-  module.exports = function (root, accessToken) {
+  module.exports = function (root, accessToken, githubHostname) {
     var timeout = 2000;
     return request;
 
@@ -28,7 +28,7 @@ else {
       var json;
       var xhr = new XMLHttpRequest();
       xhr.timeout = timeout;
-      xhr.open(method, 'https://api.github.com' + url, true);
+      xhr.open(method, (githubHostname || 'https://api.github.com') + url, true);
       xhr.setRequestHeader("Authorization", "token " + accessToken);
       if (body) {
         try { json = JSON.stringify(body); }

--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -15,6 +15,7 @@ if (isNode) {
 else {
   module.exports = function (root, accessToken, githubHostname) {
     var timeout = 2000;
+    githubHostname = (githubHostname || 'https://api.github.com');
     return request;
 
     function request(method, url, body, callback) {
@@ -28,7 +29,7 @@ else {
       var json;
       var xhr = new XMLHttpRequest();
       xhr.timeout = timeout;
-      xhr.open(method, (githubHostname || 'https://api.github.com') + url, true);
+      xhr.open(method, githubHostname + url, true);
       xhr.setRequestHeader("Authorization", "token " + accessToken);
       if (body) {
         try { json = JSON.stringify(body); }

--- a/mixins/github-db.js
+++ b/mixins/github-db.js
@@ -36,9 +36,9 @@ var emptyBlob = sha1(frame({ type: "blob", body: empty }));
 var emptyTree = sha1(frame({ type: "tree", body: empty }));
 
 // Implement the js-git object interface using github APIs
-module.exports = function (repo, root, accessToken) {
+module.exports = function (repo, root, accessToken, githubHostname) {
 
-  var apiRequest = xhr(root, accessToken);
+  var apiRequest = xhr(root, accessToken, githubHostname);
 
   repo.loadAs = loadAs;         // (type, hash) -> value, hash
   repo.saveAs = saveAs;         // (type, value) -> hash, value


### PR DESCRIPTION
This allows api.github.com to be changed to point to enterprise github implementations. 
for example 
`require('js-github/mixins/github-db')(repo, githubName, githubToken, 'https://github.example.com/api/v3')`