### PR TITLE
Various bug fixes

### DIFF
--- a/lib/xhr-node.js
+++ b/lib/xhr-node.js
@@ -1,6 +1,7 @@
 var https = require('https');
 var statusCodes = require('http').STATUS_CODES;
 var urlParse = require('url').parse;
+var path = require('path');
 
 module.exports = function (root, accessToken, githubHostname) {
   var cache = {};
@@ -36,7 +37,7 @@ module.exports = function (root, accessToken, githubHostname) {
     var urlparts = urlParse(githubHostname);
     var options = {
       hostname: urlparts.hostname,
-      path: urlparts.pathname + url,
+      path: path.join(urlparts.pathname, url),
       method: method,
       headers: headers
     };

--- a/mixins/github-db.js
+++ b/mixins/github-db.js
@@ -307,8 +307,8 @@ module.exports = function (repo, root, accessToken, githubHostname) {
 
   function listRefs(filter, callback) {
     if (!callback) return listRefs.bind(repo, filter);
-    if (!filter) filter = '';
-    return apiRequest("GET", "/repos/:root/git/refs/" + filter, onResult);
+    filter = filter ? '/' + filter : '';
+    return apiRequest("GET", "/repos/:root/git/refs" + filter, onResult);
 
     function onResult(err, xhr, result) {
       if (err) return callback(err);
@@ -535,6 +535,7 @@ function encodeDate(date) {
   var d = new Date(seconds * 1000);
   var string = d.toISOString();
   var neg = "+";
+  var offset = date.offset;
   if (offset <= 0) offset = -offset;
   else neg = "-";
   var hours = (date.offset / 60)|0;


### PR DESCRIPTION
 - When listing refs, do not add a trailing slash when no filter is
   provided.
 - When making an API request in Node, do not prepend a slash when
   creating `http.request` options.
 - Declare a previously undeclared (but used) identifier.