### PR TITLE
Adjusted updateRef() to conform in usability

### DIFF
--- a/mixins/github-db.js
+++ b/mixins/github-db.js
@@ -323,6 +323,7 @@ module.exports = function (repo, root, accessToken, githubHostname) {
 
   function updateRef(ref, hash, callback, force) {
     if (!callback) return updateRef.bind(repo, ref, hash);
+    if (ref === "HEAD") ref = "refs/heads/master";
     if (!(/^refs\//).test(ref)) {
       return callback(new Error("Invalid ref: " + ref));
     }


### PR DESCRIPTION
Added the following line 
"if (ref === "HEAD") ref = "refs/heads/master";"
Therefore, ensuring that "HEAD" is resolved to "refs/heads/master", as is done in the other methods dealing with a single Ref, like deleteRef() or readRef()