### PR TITLE
Only set auth header if token is specified

### DIFF
--- a/lib/xhr.js
+++ b/lib/xhr.js
@@ -30,7 +30,9 @@ else {
       var xhr = new XMLHttpRequest();
       xhr.timeout = timeout;
       xhr.open(method, githubHostname + url, true);
-      xhr.setRequestHeader("Authorization", "token " + accessToken);
+      if (accessToken) {
+        xhr.setRequestHeader("Authorization", "token " + accessToken);
+      }
       if (body) {
         try { json = JSON.stringify(body); }
         catch (err) { return callback(err); }


### PR DESCRIPTION
Setting the auth header without a token causes GitHub to return a 401.  This also makes xhr.js consistent with xhr-node.js.